### PR TITLE
사용자 타임존 기반 일일 리셋 로직 및 UUID 기반 세션 식별자 통일

### DIFF
--- a/src/features/calendar/hooks/useActiveSession.ts
+++ b/src/features/calendar/hooks/useActiveSession.ts
@@ -5,6 +5,7 @@ import { formatMinutes } from "../../../utils/timeUtils";
 import { isElectronEnvironment } from "../services/ElectronSessionAdapter";
 import { electronSessionAdapter } from "../services/ElectronSessionAdapter";
 import { browserCaptureService } from "../services/BrowserCaptureService";
+import { v4 as uuidv4 } from "uuid";
 
 /**
  * 캡처 관련 인터페이스
@@ -97,11 +98,13 @@ export const useActiveSession = () => {
       isRecording: boolean = false
     ): WorkSession => {
       const source = isElectron ? "electron" : "browser";
+      const sessionId = uuidv4();
       const session = timerService.startSession(
         title,
         taskType,
         source,
-        isRecording
+        isRecording,
+        sessionId
       );
 
       // 녹화 옵션이 켜져 있으면 캡처 시작

--- a/src/features/calendar/services/BrowserCaptureService.ts
+++ b/src/features/calendar/services/BrowserCaptureService.ts
@@ -1,6 +1,7 @@
 import { WorkSession } from "../types";
 import { timerService } from "./TimerService";
 import { isElectronEnvironment } from "./ElectronSessionAdapter";
+import { v4 as uuidv4 } from "uuid";
 
 // 캡처 상태 타입
 export interface BrowserCaptureState {
@@ -116,7 +117,14 @@ export class BrowserCaptureService {
       // 작업 세션 시작
       const sessionTitle = options.title || document.title || "화면 캡처";
       const category = options.category || "녹화";
-      timerService.startSession(sessionTitle, category, "browser");
+      const sessionId = uuidv4();
+      timerService.startSession(
+        sessionTitle,
+        category,
+        "browser",
+        false,
+        sessionId
+      );
 
       // 리스너 알림
       this.notifyListeners();

--- a/src/features/calendar/services/ElectronSessionAdapter.ts
+++ b/src/features/calendar/services/ElectronSessionAdapter.ts
@@ -1,5 +1,6 @@
 import { WorkSession } from "../types";
 import { timerService } from "./TimerService";
+import { v4 as uuidv4 } from "uuid";
 
 /**
  * 일렉트론 환경 감지 유틸리티 함수
@@ -69,7 +70,14 @@ export class ElectronSessionAdapter {
             // 새 세션 시작
             const title = status.windowTitle || "녹화 세션";
             const taskType = "녹화";
-            timerService.startSession(title, taskType, "electron");
+            const sessionId = uuidv4();
+            timerService.startSession(
+              title,
+              taskType,
+              "electron",
+              false,
+              sessionId
+            );
           }
         } else if (!status.isCapturing && this.isActive) {
           // 캡처 중지됨
@@ -116,7 +124,14 @@ export class ElectronSessionAdapter {
           // 새 세션 시작
           const title = "녹화 세션";
           const taskType = "녹화";
-          timerService.startSession(title, taskType, "electron");
+          const sessionId = uuidv4();
+          timerService.startSession(
+            title,
+            taskType,
+            "electron",
+            false,
+            sessionId
+          );
         }
       }
 

--- a/src/features/calendar/services/SessionManager.ts
+++ b/src/features/calendar/services/SessionManager.ts
@@ -264,13 +264,15 @@ export class SessionManager {
     title: string,
     taskType: string,
     source: "electron" | "browser" | "manual" = "manual",
-    isRecording: boolean = false
+    isRecording: boolean = false,
+    sessionId?: string
   ): WorkSession {
     const session = timerService.startSession(
       title,
       taskType,
       source,
-      isRecording
+      isRecording,
+      sessionId
     );
 
     // 세션 목록 갱신

--- a/src/features/calendar/services/TimerService.ts
+++ b/src/features/calendar/services/TimerService.ts
@@ -1,6 +1,7 @@
 import { WorkSession } from "../types";
 import { sessionStorageService } from "./SessionStorageService";
 import { DateService } from "./DateService";
+import { v4 as uuidv4 } from "uuid";
 
 // 타이머 이벤트 타입
 export type TimerEventType =
@@ -117,7 +118,8 @@ export class TimerService {
     title: string,
     taskType: string,
     source: "electron" | "browser" | "manual" = "manual",
-    isRecording: boolean = false
+    isRecording: boolean = false,
+    sessionId?: string
   ): WorkSession {
     // 기존 세션이 있으면 중지
     if (this.activeSession) {
@@ -127,7 +129,7 @@ export class TimerService {
     // 새 세션 생성
     const now = new Date();
     const newSession: WorkSession = {
-      id: Date.now().toString(),
+      id: sessionId || uuidv4(),
       date: DateService.startOfDay(now), // 날짜 정규화 (시간 부분 제거)
       startTime: now,
       endTime: null,

--- a/src/features/settings/components/GeneralSettings.tsx
+++ b/src/features/settings/components/GeneralSettings.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { AppSettings } from "../../calendar/types";
+import SettingOption from "./SettingOption";
+
+interface GeneralSettingsProps {
+  settings: AppSettings;
+  onChangeSettings: (settings: Partial<AppSettings>) => void;
+}
+
+/**
+ * 일반 설정 컴포넌트
+ */
+const GeneralSettings: React.FC<GeneralSettingsProps> = ({
+  settings,
+  onChangeSettings,
+}) => {
+  // 타임존 목록 - 주요 타임존만 포함
+  const timezones = [
+    "Asia/Seoul",
+    "Asia/Tokyo",
+    "Asia/Shanghai",
+    "Asia/Singapore",
+    "Australia/Sydney",
+    "Europe/London",
+    "Europe/Paris",
+    "Europe/Berlin",
+    "America/New_York",
+    "America/Los_Angeles",
+    "America/Chicago",
+    "Pacific/Auckland",
+    "UTC",
+  ];
+
+  // 리셋 시간 목록 (0-23)
+  const resetHours = Array.from({ length: 24 }, (_, i) => i);
+
+  // 타임존 변경 핸들러
+  const handleTimezoneChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onChangeSettings({ timezone: e.target.value });
+  };
+
+  // 리셋 시간 변경 핸들러
+  const handleResetHourChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onChangeSettings({ resetHour: parseInt(e.target.value, 10) });
+  };
+
+  return (
+    <div className="space-y-4">
+      <SettingOption
+        label="타임존"
+        description="작업 일자 계산에 사용될 타임존을 선택하세요."
+      >
+        <select
+          value={settings.timezone}
+          onChange={handleTimezoneChange}
+          className="py-2 px-3 rounded bg-[var(--bg-primary)] text-[var(--text-normal)] border border-[var(--border-color)] w-full"
+        >
+          {timezones.map((tz) => (
+            <option key={tz} value={tz}>
+              {tz}
+            </option>
+          ))}
+        </select>
+      </SettingOption>
+
+      <SettingOption
+        label="일일 리셋 시간"
+        description="세션이 자동으로 종료되고 새로운 날로 간주될 시간을 설정하세요."
+      >
+        <select
+          value={settings.resetHour}
+          onChange={handleResetHourChange}
+          className="py-2 px-3 rounded bg-[var(--bg-primary)] text-[var(--text-normal)] border border-[var(--border-color)] w-full"
+        >
+          {resetHours.map((hour) => (
+            <option key={hour} value={hour}>
+              {hour.toString().padStart(2, "0")}:00
+            </option>
+          ))}
+        </select>
+      </SettingOption>
+    </div>
+  );
+};
+
+export default GeneralSettings;

--- a/src/features/settings/components/SettingOption.tsx
+++ b/src/features/settings/components/SettingOption.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { SettingOptionProps } from "../types";
+
+/**
+ * 설정 옵션 컴포넌트
+ */
+const SettingOption: React.FC<SettingOptionProps> = ({
+  label,
+  description,
+  children,
+}) => {
+  return (
+    <div className="mb-4">
+      <div className="flex flex-col mb-2">
+        <label className="font-medium text-[var(--text-normal)] mb-1">
+          {label}
+        </label>
+        {description && (
+          <p className="text-sm text-[var(--text-muted)] mb-2">{description}</p>
+        )}
+      </div>
+      <div className="w-full">{children}</div>
+    </div>
+  );
+};
+
+export default SettingOption;

--- a/src/features/settings/components/Settings.tsx
+++ b/src/features/settings/components/Settings.tsx
@@ -2,12 +2,15 @@ import React from "react";
 import { useSettings } from "../hooks/useSettings";
 import SettingsSection from "./SettingsSection";
 import TimelapseSettings from "./TimelapseSettings";
+import GeneralSettings from "./GeneralSettings";
 
 /**
  * 설정 메인 컴포넌트
  */
 const Settings: React.FC = () => {
   const {
+    generalSettings,
+    updateGeneralSettings,
     timelapseOptions,
     changeTimelapseOptions,
     saveFolderPath,
@@ -36,6 +39,13 @@ const Settings: React.FC = () => {
         <h2 className="text-white text-xl mb-4 text-center font-semibold">
           설정
         </h2>
+
+        <SettingsSection title="일반 설정">
+          <GeneralSettings
+            settings={generalSettings}
+            onChangeSettings={updateGeneralSettings}
+          />
+        </SettingsSection>
 
         <SettingsSection title="타임랩스 설정">
           <TimelapseSettings

--- a/src/features/settings/hooks/useSettings.ts
+++ b/src/features/settings/hooks/useSettings.ts
@@ -1,11 +1,18 @@
-import { useCallback } from "react";
+import { useCallback, useState, useEffect } from "react";
 import { useTimelapseGenerationCapture } from "../../timelapse";
+import { AppSettings } from "../../calendar/types";
+import { sessionStorageService } from "../../calendar/services/SessionStorageService";
 
 /**
  * 설정 관리 훅
  * - 다양한 설정 관련 훅들을 통합
  */
 export const useSettings = () => {
+  // 일반 앱 설정 상태
+  const [generalSettings, setGeneralSettings] = useState<AppSettings>(
+    sessionStorageService.getSettings()
+  );
+
   // 타임랩스 관련 설정 불러오기
   const {
     timelapseOptions,
@@ -14,13 +21,36 @@ export const useSettings = () => {
     selectSaveFolder,
   } = useTimelapseGenerationCapture();
 
-  // 설정 저장 핸들러
-  const saveSettings = useCallback(() => {
-    // 현재는 별도 저장 로직이 필요 없음 (옵션 변경 시 자동 저장됨)
-    return true;
+  // 초기 설정 로드
+  useEffect(() => {
+    setGeneralSettings(sessionStorageService.getSettings());
   }, []);
 
+  // 일반 설정 업데이트 핸들러
+  const updateGeneralSettings = useCallback(
+    (newSettings: Partial<AppSettings>) => {
+      setGeneralSettings((prevSettings) => {
+        const updatedSettings = { ...prevSettings, ...newSettings };
+        sessionStorageService.saveSettings(updatedSettings);
+        return updatedSettings;
+      });
+    },
+    []
+  );
+
+  // 설정 저장 핸들러
+  const saveSettings = useCallback(() => {
+    // 일반 설정 저장
+    sessionStorageService.saveSettings(generalSettings);
+    // 나중에 다른 설정들도 여기에 추가할 수 있음
+    return true;
+  }, [generalSettings]);
+
   return {
+    // 일반 설정
+    generalSettings,
+    updateGeneralSettings,
+
     // 타임랩스 설정
     timelapseOptions,
     changeTimelapseOptions,

--- a/src/features/timelapse/hooks/useWorkSession.ts
+++ b/src/features/timelapse/hooks/useWorkSession.ts
@@ -149,10 +149,11 @@ export function useWorkSession() {
     (sessionData: Omit<WorkSession, "id" | "date" | "duration">) => {
       const now = new Date();
       const today = DateService.startOfDay(now);
+      const sessionId = uuidv4();
 
       // 새 세션 생성
       const newSession: WorkSession = {
-        id: uuidv4(),
+        id: sessionId,
         date: today,
         duration: 0,
         ...sessionData,
@@ -174,7 +175,8 @@ export function useWorkSession() {
         newSession.title,
         newSession.taskType,
         newSession.source || "manual",
-        newSession.isRecording || false
+        newSession.isRecording || false,
+        sessionId
       );
 
       // 화면 상태 업데이트


### PR DESCRIPTION
## 변경사항 요약

### 1. 오전 9시 리셋 로직 타임존 지원
- 하드코딩된 오전 9시 리셋 시간을 사용자 설정 기반으로 변경
- 타임존을 고려한 날짜 비교 로직 추가
- DateService에 타임존 유틸리티 함수 3개 추가:
  - getDateWithHourInTimezone
  - getTimezoneOffsetString
  - isSameDayInTimezone
- 사용자 타임존 및 리셋 시간 설정 UI 구현

### 2. 세션 식별자 생성 방식 통일
- 모든 세션 ID 생성 방식을 UUID v4로 표준화
- TimerService에 선택적 sessionId 매개변수 추가
- ID 충돌 가능성 제거 및 예측 가능한 식별자 체계 구축

## 배경

1. 타임존별 리셋 로직이 필요한 이유:
   - 다양한 국가/지역 사용자에게 일관된 경험 제공
   - 사용자가 자신에게 맞는 리셋 시간 설정 가능

2. 세션 ID 생성 방식 통일의 필요성:
   - 기존 방식(Date.now())에서는 동일 시점 생성 시 ID 충돌 가능성 존재
   - 다양한 코드베이스에서 일관성 없는 ID 생성 방식 사용
